### PR TITLE
Generated parser filenames fix

### DIFF
--- a/src/tag/code_generator/__main__.py
+++ b/src/tag/code_generator/__main__.py
@@ -145,17 +145,8 @@ with open(sys.argv[1], "w") as f:
         with open(sys.argv[bitfield_cpp+1], "w") as ecpp:
             make_definitions(f, ecpp, bcpp, all_enums, all_bitfields, all_structs_arranged)
 
-with open(sys.argv[2], "w") as hpp:
-    with open(sys.argv[3], "w") as cpp_save_hek_data:
-        with open(sys.argv[4], "w") as cpp_read_hek_data:
-            with open(sys.argv[5], "w") as cpp_read_cache_file_data:
-                with open(sys.argv[6], "w") as cpp_cache_format_data:
-                    with open(sys.argv[7], "w") as cpp_cache_deformat_data:
-                        with open(sys.argv[8], "w") as cpp_refactor_reference:
-                            with open(sys.argv[9], "w") as cpp_struct_value:
-                                with open(sys.argv[10], "w") as cpp_check_invalid_ranges:
-                                    with open(sys.argv[11], "w") as cpp_check_invalid_indices:
-                                        with open(sys.argv[12], "w") as cpp_normalize:
-                                            with open(sys.argv[13], "w") as cpp_hek_file:
-                                                with open(sys.argv[14], "w") as cpp_scan_padding:
-                                                    make_parser(all_enums, all_bitfields, all_structs_arranged, all_structs, hpp, cpp_save_hek_data, cpp_read_hek_data, cpp_read_cache_file_data, cpp_cache_format_data, cpp_cache_deformat_data, cpp_refactor_reference, cpp_struct_value, cpp_check_invalid_ranges, cpp_check_invalid_indices, cpp_normalize, cpp_hek_file, cpp_scan_padding)
+parser_files = map(lambda fname: open(fname, "w"), sys.argv[2:15])
+make_parser(all_enums, all_bitfields, all_structs_arranged, all_structs,
+            *parser_files)
+for f in parser_files:
+    f.close()

--- a/src/tag/code_generator/__main__.py
+++ b/src/tag/code_generator/__main__.py
@@ -147,8 +147,8 @@ with open(sys.argv[1], "w") as f:
 
 with open(sys.argv[2], "w") as hpp:
     with open(sys.argv[3], "w") as cpp_save_hek_data:
-        with open(sys.argv[4], "w") as cpp_read_cache_file_data:
-            with open(sys.argv[5], "w") as cpp_read_hek_data:
+        with open(sys.argv[4], "w") as cpp_read_hek_data:
+            with open(sys.argv[5], "w") as cpp_read_cache_file_data:
                 with open(sys.argv[6], "w") as cpp_cache_format_data:
                     with open(sys.argv[7], "w") as cpp_cache_deformat_data:
                         with open(sys.argv[8], "w") as cpp_refactor_reference:
@@ -158,4 +158,4 @@ with open(sys.argv[2], "w") as hpp:
                                         with open(sys.argv[12], "w") as cpp_normalize:
                                             with open(sys.argv[13], "w") as cpp_hek_file:
                                                 with open(sys.argv[14], "w") as cpp_scan_padding:
-                                                    make_parser(all_enums, all_bitfields, all_structs_arranged, all_structs, hpp, cpp_save_hek_data, cpp_read_cache_file_data, cpp_read_hek_data, cpp_cache_format_data, cpp_cache_deformat_data, cpp_refactor_reference, cpp_struct_value, cpp_check_invalid_ranges, cpp_check_invalid_indices, cpp_normalize, cpp_hek_file, cpp_scan_padding)
+                                                    make_parser(all_enums, all_bitfields, all_structs_arranged, all_structs, hpp, cpp_save_hek_data, cpp_read_hek_data, cpp_read_cache_file_data, cpp_cache_format_data, cpp_cache_deformat_data, cpp_refactor_reference, cpp_struct_value, cpp_check_invalid_ranges, cpp_check_invalid_indices, cpp_normalize, cpp_hek_file, cpp_scan_padding)

--- a/src/tag/code_generator/parser.py
+++ b/src/tag/code_generator/parser.py
@@ -14,7 +14,7 @@ from check_invalid_indices import make_check_invalid_indices
 from check_normalize import make_normalize
 from scan_padding import make_scan_padding
 
-def make_parser(all_enums, all_bitfields, all_structs_arranged, all_structs, hpp, cpp_save_hek_data, cpp_read_cache_file_data, cpp_read_hek_data, cpp_cache_format_data, cpp_cache_deformat_data, cpp_refactor_reference, cpp_struct_value, cpp_check_invalid_ranges, cpp_check_invalid_indices, cpp_normalize, cpp_read_hek_file, cpp_scan_padding):
+def make_parser(all_enums, all_bitfields, all_structs_arranged, all_structs, hpp, cpp_save_hek_data, cpp_read_hek_data, cpp_read_cache_file_data, cpp_cache_format_data, cpp_cache_deformat_data, cpp_refactor_reference, cpp_struct_value, cpp_check_invalid_ranges, cpp_check_invalid_indices, cpp_normalize, cpp_read_hek_file, cpp_scan_padding):
     def write_for_all_cpps(what):
         cpp_save_hek_data.write(what)
         cpp_read_cache_file_data.write(what)


### PR DESCRIPTION
Hey, two of the parser filenames (`parser-read-hek-data`, `parser-read-cache-file-data`) are swapped because of an order mix-up in `src/invader.cmake` and  `src/tag/code_generator/__main.py__`. Currently,  `parse_cache_file_data` methods are written to `parser-read-hek-data.cpp` and `parse_hek_tag_data` methods are written to `parser-read-cache-file-data.cpp`.

The first commit fixes this, the second commit removes one of the manual mappings so there is one less place to accidentally write them in the wrong order.