### PR TITLE
invader-archive cmake flag fix

### DIFF
--- a/src/archive/archive.cmake
+++ b/src/archive/archive.cmake
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+if(NOT ${LibArchive_FOUND})
+    set(INVADER_ARCHIVE false)
+    message(WARNING "Unable to automatically find libarchive; invader-archive will be disabled")
+endif()
+
 if(NOT DEFINED ${INVADER_ARCHIVE})
-    if(${LibArchive_FOUND})
-        set(INVADER_ARCHIVE true)
-    else()
-        set(INVADER_ARCHIVE false)
-        message(WARNING "Unable to automatically find libarchive; invader-archive will be disabled")
-    endif()
-    set(INVADER_ARCHIVE ${INVADER_ARCHIVE} CACHE BOOL "Build invader-archive (archives tags; requires libarchive)")
+    set(INVADER_ARCHIVE true CACHE BOOL "Build invader-archive (archives tags; requires libarchive)")
 endif()
 
 if(${INVADER_ARCHIVE})


### PR DESCRIPTION
Prevent invader-archive from being built automatically when libarchive is found, even if its flag is unchecked.